### PR TITLE
Problem: sending too many transactions

### DIFF
--- a/bridge/src/bridge/batch.rs
+++ b/bridge/src/bridge/batch.rs
@@ -1,0 +1,19 @@
+use std::collections::VecDeque;
+pub fn batch<I: Iterator, F, T>(iter: I, f: F, batch_size: usize) -> VecDeque<T>
+    where F: Fn(Vec<I::Item>) -> T {
+	let mut batches: VecDeque<T> = VecDeque::new();
+	let mut batch = Vec::with_capacity(batch_size);
+	let mut len = 0;
+	for deposit in iter {
+		len += 1;
+		batch.push(deposit);
+		if batch.len() == batch_size {
+			batches.push_back(f(batch));
+			batch = Vec::with_capacity(batch_size);
+		}
+	}
+	if batch.len() > 0 || len == 0 {
+		batches.push_back(f(batch));
+	}
+	batches
+}

--- a/bridge/src/bridge/mod.rs
+++ b/bridge/src/bridge/mod.rs
@@ -1,3 +1,5 @@
+mod batch;
+mod sequentially;
 mod deploy;
 mod deposit_relay;
 mod withdraw_confirm;
@@ -97,7 +99,7 @@ pub struct Bridge<T: Transport, F> {
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-impl<T: Transport, F: BridgeBackend> Stream for Bridge<T, F> {
+impl<T: Transport, F: BridgeBackend> Stream for Bridge<T, F> where T::Out: 'static {
 	type Item = ();
 	type Error = Error;
 

--- a/bridge/src/bridge/sequentially.rs
+++ b/bridge/src/bridge/sequentially.rs
@@ -1,0 +1,7 @@
+use futures::Future;
+pub fn sequentially<F: Future, I: IntoIterator<Item = Box<F>>>(iter: I) -> Box<Future<Item = F::Item, Error = F::Error>>
+    where F::Item: 'static, F::Error: 'static, F: 'static {
+	let mut iter = iter.into_iter();
+	let first = iter.next().unwrap();
+	iter.fold(first, |acc, next| Box::new(acc.and_then(|_| next)))
+}

--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -10,6 +10,7 @@ use {toml};
 const DEFAULT_POLL_INTERVAL: u64 = 1;
 const DEFAULT_CONFIRMATIONS: usize = 12;
 const DEFAULT_TIMEOUT: u64 = 5;
+const DEFAULT_SIMULTANEOUS_REQUESTS_PER_BATCH: usize = 2;
 
 /// Application config.
 #[derive(Debug, PartialEq, Clone)]
@@ -58,6 +59,7 @@ pub struct Node {
 	pub request_timeout: Duration,
 	pub poll_interval: Duration,
 	pub required_confirmations: usize,
+	pub simultaneous_requests_per_batch: usize,
 }
 
 impl Node {
@@ -76,6 +78,7 @@ impl Node {
 			request_timeout: Duration::from_secs(node.request_timeout.unwrap_or(DEFAULT_TIMEOUT)),
 			poll_interval: Duration::from_secs(node.poll_interval.unwrap_or(DEFAULT_POLL_INTERVAL)),
 			required_confirmations: node.required_confirmations.unwrap_or(DEFAULT_CONFIRMATIONS),
+			simultaneous_requests_per_batch: node.simultaneous_requests_per_batch.unwrap_or(DEFAULT_SIMULTANEOUS_REQUESTS_PER_BATCH),
 		};
 
 		Ok(result)
@@ -155,6 +158,7 @@ mod load {
 		pub request_timeout: Option<u64>,
 		pub poll_interval: Option<u64>,
 		pub required_confirmations: Option<usize>,
+		pub simultaneous_requests_per_batch: Option<usize>,
 	}
 
 	#[derive(Deserialize)]


### PR DESCRIPTION
When too many transactions are being sent out, the response
from the node comes after the operation has timed out.

This is particularly noticeable on heavy loads on slower
computers.

Solution: chunk transactions into batches

By default, the size of the batch is 2, however, it is important
to note that since there's no coordination between different
parties, there might be more than one batch at a time (but they
should be within a single digit since the number of operations
performed by bridge is limited)

Addresses #33 (partially)