### PR TITLE
added README to reflect that contracts are for integration tests only

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,3 @@
+These contracts are outdated and used for integration testing (so far) only.
+
+Please use the bridge with contracts located in [POA Bridge Smart Contracts](https://github.com/poanetwork/poa-bridge-contracts) 


### PR DESCRIPTION
Contracts in the repo are not used for the bridge any more.
So, in order to reduce number of questions in the future, a note to reflect the status of contracts is added.