### PR TITLE
Problem: bridge sends out transactions slowly

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ withdraw_confirm = { gas = 3000000, gas_price = 1000000000 }
 - `home/foreign.rpc_port` - RPC port (**defaults to 8545**)
 - `home/foreign.required_confirmations` - number of confirmation required to consider transaction final on home (default: **12**)
 - `home/foreign.poll_interval` - specify how often home node should be polled for changes (in seconds, default: **1**)
-- `home/foreign.request_timeout` - specify request timeout (in seconds, default: **5**)
+- `home/foreign.request_timeout` - specify request timeout (in seconds, default: **3600**)
 - `home/foreign.password` - path to the file containing a password for the validator's account (to decrypt the key from the keystore)
 
 #### authorities options
@@ -127,10 +127,13 @@ withdraw_confirm = { gas = 3000000, gas_price = 1000000000 }
 
 - `transaction.deposit_relay.gas` - specify how much gas should be consumed by deposit relay
 - `transaction.deposit_relay.gas_price` - specify gas price for deposit relay
+- `transaction.deposit_relay.concurrency` - how many concurrent transactions can be sent (default: **100**)
 - `transaction.withdraw_confirm.gas` - specify how much gas should be consumed by withdraw confirm
 - `transaction.withdraw_confirm.gas_price` - specify gas price for withdraw confirm
+- `transaction.withdraw_confirm.concurrency` - how many concurrent transactions can be sent (default: **100**)
 - `transaction.withdraw_relay.gas` - specify how much gas should be consumed by withdraw relay
 - `transaction.withdraw_relay.gas_price` - specify gas price for withdraw relay
+- `transaction.withdraw_relay.concurrency` - how many concurrent transactions can be sent (default: **100**)
 
 ### Database file format
 

--- a/bridge/src/bridge/deposit_relay.rs
+++ b/bridge/src/bridge/deposit_relay.rs
@@ -109,7 +109,7 @@ impl<T: Transport> Stream for DepositRelay<T> {
 
 					info!("relaying {} deposits", len);
 					DepositRelayState::RelayDeposits {
-						future: iter_ok(deposits).buffered(1).collect(),
+						future: iter_ok(deposits).buffered(self.app.config.txs.deposit_relay.concurrency).collect(),
 						block: item.to,
 					}
 				},

--- a/bridge/src/bridge/mod.rs
+++ b/bridge/src/bridge/mod.rs
@@ -85,8 +85,8 @@ pub fn create_bridge_backed_by<T: Transport + Clone, F: BridgeBackend>(app: Arc<
 	let home_balance = Arc::new(RwLock::new(None));
 	let foreign_balance = Arc::new(RwLock::new(None));
 	Bridge {
-		foreign_balance_check: create_balance_check(app.connections.foreign.clone(), app.config.foreign.clone()),
-		home_balance_check: create_balance_check(app.connections.home.clone(), app.config.home.clone()),
+		foreign_balance_check: create_balance_check(app.clone(), app.connections.foreign.clone(), app.config.foreign.clone()),
+		home_balance_check: create_balance_check(app.clone(), app.connections.home.clone(), app.config.home.clone()),
 		foreign_balance: foreign_balance.clone(),
 		home_balance: home_balance.clone(),
 		deposit_relay: create_deposit_relay(app.clone(), init, foreign_balance.clone(), foreign_chain_id),

--- a/bridge/src/bridge/withdraw_confirm.rs
+++ b/bridge/src/bridge/withdraw_confirm.rs
@@ -136,7 +136,7 @@ impl<T: Transport> Stream for WithdrawConfirm<T> {
 
 					info!("submitting {} signatures", len);
 					WithdrawConfirmState::ConfirmWithdraws {
-						future: iter_ok(confirmations).buffered(1).collect(),
+						future: iter_ok(confirmations).buffered(self.app.config.txs.withdraw_confirm.concurrency).collect(),
 						block,
 					}
 				},

--- a/bridge/src/bridge/withdraw_relay.rs
+++ b/bridge/src/bridge/withdraw_relay.rs
@@ -232,7 +232,7 @@ impl<T: Transport> Stream for WithdrawRelay<T> {
 
 					info!("relaying {} withdraws", len);
 					WithdrawRelayState::RelayWithdraws {
-						future: iter_ok(relays).buffered(1).collect(),
+						future: iter_ok(relays).buffered(self.app.config.txs.withdraw_relay.concurrency).collect(),
 						block,
 					}
 				},

--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -12,8 +12,9 @@ use {toml};
 
 const DEFAULT_POLL_INTERVAL: u64 = 1;
 const DEFAULT_CONFIRMATIONS: usize = 12;
-const DEFAULT_TIMEOUT: u64 = 5;
+const DEFAULT_TIMEOUT: u64 = 3600;
 const DEFAULT_RPC_PORT: u16 = 8545;
+const DEFAULT_CONCURRENCY: usize = 100;
 
 /// Application config.
 #[derive(Debug, PartialEq, Clone)]
@@ -158,6 +159,7 @@ impl Transactions {
 pub struct TransactionConfig {
 	pub gas: u64,
 	pub gas_price: u64,
+	pub concurrency: usize,
 }
 
 impl TransactionConfig {
@@ -165,6 +167,7 @@ impl TransactionConfig {
 		TransactionConfig {
 			gas: cfg.gas.unwrap_or_default(),
 			gas_price: cfg.gas_price.unwrap_or_default(),
+			concurrency: cfg.concurrency.unwrap_or(DEFAULT_CONCURRENCY),
 		}
 	}
 }
@@ -228,6 +231,7 @@ mod load {
 	pub struct TransactionConfig {
 		pub gas: Option<u64>,
 		pub gas_price: Option<u64>,
+		pub concurrency: Option<usize>,
 	}
 
 	#[derive(Deserialize)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -140,8 +140,8 @@ fn execute<S, I>(command: I, running: Arc<AtomicBool>) -> Result<String, UserFac
 	let app = Arc::new(app);
 
 	info!(target: "bridge", "Acquiring home & foreign chain ids");
-	let home_chain_id = event_loop.run(create_chain_id_retrieval(app.connections.home.clone(), app.config.home.clone())).expect("can't retrieve home chain_id");
-	let foreign_chain_id = event_loop.run(create_chain_id_retrieval(app.connections.foreign.clone(), app.config.foreign.clone())).expect("can't retrieve foreign chain_id");
+	let home_chain_id = event_loop.run(create_chain_id_retrieval(app.clone(), app.connections.home.clone(), app.config.home.clone())).expect("can't retrieve home chain_id");
+	let foreign_chain_id = event_loop.run(create_chain_id_retrieval(app.clone(), app.connections.foreign.clone(), app.config.foreign.clone())).expect("can't retrieve foreign chain_id");
 
 	info!(target: "bridge", "Home chain ID: {} Foreign chain ID: {}", home_chain_id, foreign_chain_id);
 


### PR DESCRIPTION
This is because it is limiting them to one at a time
per operation type. This was done so that there's no
gaps in nonces due to undelivered transactions.
    
Solution: allow concurrent sending of transactions
    
By default, 100 transactions are allowed.
    
Note, however, that now there's a chance that nonce
gaps may be formed under cerain circumstances.
