### PR TITLE
Problem: home_deploy and foreign_deploy fields

### DIFF
--- a/bridge/src/bridge/deploy.rs
+++ b/bridge/src/bridge/deploy.rs
@@ -122,8 +122,8 @@ impl<T: Transport + Clone> Future for Deploy<T> {
 					let database = Database {
 						home_contract_address: main_receipt.contract_address.expect("contract creation receipt must have an address; qed"),
 						foreign_contract_address: test_receipt.contract_address.expect("contract creation receipt must have an address; qed"),
-						home_deploy: main_receipt.block_number.low_u64(),
-						foreign_deploy: test_receipt.block_number.low_u64(),
+						home_deploy: Some(main_receipt.block_number.low_u64()),
+						foreign_deploy: Some(test_receipt.block_number.low_u64()),
 						checked_deposit_relay: main_receipt.block_number.low_u64(),
 						checked_withdraw_relay: test_receipt.block_number.low_u64(),
 						checked_withdraw_confirm: test_receipt.block_number.low_u64(),

--- a/bridge/src/database.rs
+++ b/bridge/src/database.rs
@@ -13,9 +13,9 @@ pub struct Database {
 	/// Address of foreign contract.
 	pub foreign_contract_address: Address,
 	/// Number of block at which home contract has been deployed.
-	pub home_deploy: u64,
+	pub home_deploy: Option<u64>,
 	/// Number of block at which foreign contract has been deployed.
-	pub foreign_deploy: u64,
+	pub foreign_deploy: Option<u64>,
 	/// Number of last block which has been checked for deposit relays.
 	pub checked_deposit_relay: u64,
 	/// Number of last block which has been checked for withdraw relays.


### PR DESCRIPTION
These fields in database are no longer useful outside of
integration testing.

Solution: make them optional

Closes #67