### PR TITLE
Problem: Foreign RPC URL is not reported in the logs

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -125,6 +125,7 @@ fn execute<S, I>(command: I, running: Arc<AtomicBool>) -> Result<String, UserFac
 	let mut event_loop = Core::new().unwrap();
 
 	info!(target: "bridge", "Home rpc host {}", config.clone().home.rpc_host);
+	info!(target: "bridge", "Foreign rpc host {}", config.clone().foreign.rpc_host);
 
 	info!(target: "bridge", "Establishing connection:");
 


### PR DESCRIPTION
The current behavior for logs displayed during the bridge initialization
is not consistent - home url is reported whereas foreign url is not.

Solution: report it

Fixes #69