### PR TITLE
Problem: errors do not show their context

### DIFF
--- a/bridge/src/bridge/mod.rs
+++ b/bridge/src/bridge/mod.rs
@@ -159,19 +159,22 @@ impl<T: Transport, F: BridgeBackend> Stream for Bridge<T, F> {
 						return Ok(Async::NotReady)
 					}
 
-					let d_relay = try_bridge!(self.deposit_relay.poll()).map(BridgeChecked::DepositRelay);
+					let d_relay = try_bridge!(self.deposit_relay.poll().map_err(|e| ErrorKind::ContextualizedError(Box::new(e), "deposit_relay")))
+						.map(BridgeChecked::DepositRelay);
 
 					if d_relay.is_some() {
 						self.check_balances()?;
 					}
 
-					let w_relay = try_bridge!(self.withdraw_relay.poll()).map(BridgeChecked::WithdrawRelay);
+					let w_relay = try_bridge!(self.withdraw_relay.poll().map_err(|e| ErrorKind::ContextualizedError(Box::new(e), "withdraw_relay"))).
+						map(BridgeChecked::WithdrawRelay);
 
 					if w_relay.is_some() {
 						self.check_balances()?;
 					}
 
-					let w_confirm = try_bridge!(self.withdraw_confirm.poll()).map(BridgeChecked::WithdrawConfirm);
+					let w_confirm = try_bridge!(self.withdraw_confirm.poll().map_err(|e| ErrorKind::ContextualizedError(Box::new(e), "withdraw_confirm"))).
+						map(BridgeChecked::WithdrawConfirm);
 
 					if w_confirm.is_some() {
 						self.check_balances()?;

--- a/bridge/src/bridge/withdraw_confirm.rs
+++ b/bridge/src/bridge/withdraw_confirm.rs
@@ -84,7 +84,7 @@ impl<T: Transport> Stream for WithdrawConfirm<T> {
 						return Ok(futures::Async::NotReady);
 					}
 
-					let item = try_stream!(self.logs.poll());
+					let item = try_stream!(self.logs.poll().map_err(|e| ErrorKind::ContextualizedError(Box::new(e), "polling foreign for withdrawals")));
 					let len = item.logs.len();
 					info!("got {} new withdraws to sign", len);
 					let mut messages = item.logs
@@ -141,7 +141,7 @@ impl<T: Transport> Stream for WithdrawConfirm<T> {
 					}
 				},
 				WithdrawConfirmState::ConfirmWithdraws { ref mut future, block } => {
-					let _ = try_ready!(future.poll());
+					let _ = try_ready!(future.poll().map_err(|e| ErrorKind::ContextualizedError(Box::new(e), "sending signature submissions to foreign")));
 					info!("submitting signatures complete");
 					WithdrawConfirmState::Yield(Some(block))
 				},

--- a/bridge/src/error.rs
+++ b/bridge/src/error.rs
@@ -50,6 +50,10 @@ error_chain! {
 		    description("account error")
 		    display("account error {:?}", err),
 		}
+		ContextualizedError(err: Box<Error>, context: &'static str) {
+		    description("contextualized error")
+		    display("{:?} in {}", err, context)
+		}
 	}
 }
 

--- a/bridge/src/lib.rs
+++ b/bridge/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit="128"]
 #[macro_use]
 extern crate futures;
 extern crate serde;


### PR DESCRIPTION
If the error like this appears in the logs:
```
INFO:bridge::bridge::withdraw_confirm: waiting for new withdraws that
should get signed
WARN:bridge: Bridge crashed with Error(Transport("Incomplete"), State {
next_error: None, backtrace: None })
Error(Transport("Incomplete"), State { next_error: None, backtrace: None
})
```
it is hard to understand which side of the bridge failed. The message
must contains type of operation (`deposit_relay`, `withdraw_confirm` or
`withdraw_relay`) and side of bridge (URL of RPC channel).

Solution: record error's top level context and print it out if recorded

Addresses #75