### PR TITLE
Problem: insecure RPCs are subject to MITM attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ bridge --config config.toml --database db.toml
 - `--config` - location of the configuration file. configuration file must exist
 - `--database` - location of the database file.
 
+Bridge forces TLS for RPC connections by default. However, in some limited scenarios (like local testing),
+this might be undesirable. In this case, you can use `--allow-insecure-rpc-endpoints` option to allow non-TLS
+endpoints to be used. Ensure, however, that this option is not going to be used in production.
+
+
 #### Exit Status Codes
 
 | Code | Meaning              |

--- a/bridge/src/error.rs
+++ b/bridge/src/error.rs
@@ -61,6 +61,10 @@ error_chain! {
 		OtherError(error: String) {
 		    description("other error")
 		    display("{}", error)
+        }
+		ConfigError(err: String) {
+		    description("config error")
+		    display("{}", err)
 		}
 	}
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -73,13 +73,14 @@ POA-Ethereum bridge.
     Copyright 2018 POA Networks Ltd.
 
 Usage:
-    bridge --config <config> --database <database>
+    bridge [options] --config <config> --database <database>
     bridge -h | --help
     bridge -v | --version
 
 Options:
-    -h, --help           Display help message and exit.
-    -v, --version        Print version and exit.
+    -h, --help                        Display help message and exit.
+    -v, --version                     Print version and exit.
+    --allow-insecure-rpc-endpoints    Allow non-HTTPS endpoints
 "#;
 
 #[derive(Debug, Deserialize)]
@@ -87,6 +88,7 @@ pub struct Args {
 	arg_config: PathBuf,
 	arg_database: PathBuf,
 	flag_version: bool,
+	flag_allow_insecure_rpc_endpoints: bool,
 }
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -128,7 +130,7 @@ fn execute<S, I>(command: I, running: Arc<AtomicBool>) -> Result<String, UserFac
 	}
 
 	info!(target: "bridge", "Loading config");
-	let config = Config::load(args.arg_config)?;
+	let config = Config::load(args.arg_config, args.flag_allow_insecure_rpc_endpoints)?;
 
 	info!(target: "bridge", "Starting event loop");
 	let mut event_loop = Core::new().unwrap();

--- a/integration-tests/tests/basic_deposit_then_withdraw.rs
+++ b/integration-tests/tests/basic_deposit_then_withdraw.rs
@@ -163,6 +163,7 @@ fn test_basic_deposit_then_withdraw() {
 		.env("RUST_LOG", "info")
 		.arg("--config").arg("bridge_config.toml")
 		.arg("--database").arg("tmp/bridge1_db.txt")
+		.arg("--allow-insecure-rpc-endpoints")
 		.spawn()
 		.expect("failed to spawn bridge process");
 

--- a/integration-tests/tests/insufficient_funds.rs
+++ b/integration-tests/tests/insufficient_funds.rs
@@ -194,6 +194,7 @@ fn test_insufficient_funds() {
 		.env("RUST_LOG", "info")
 		.arg("--config").arg("bridge_config_gas_price.toml")
 		.arg("--database").arg("tmp/bridge1_db.txt")
+		.arg("--allow-insecure-rpc-endpoints")
 		.spawn()
 		.expect("failed to spawn bridge process");
 


### PR DESCRIPTION
Solution: by default, disallow use of non-TLS RPC endpoints

For testing, there's an escape hatch of a command line
argument `--allow-insecure-rpc-endpoints` (purposefully
long) that will reduce the severity of using a non-TLS
RPC endpoint to a warning in a log file.

It was not made to be a configuration file option to reduce
the risk of this option slipping into a production configuration
file by mistake.

Closes #79