### PR TITLE
Problem: the readme and example config TOML files include obsolete gas-price config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ and they can convert them back as well.
 
 Requires `rust` and `cargo`: [installation instructions.](https://www.rust-lang.org/en-US/install.html)
 
+Requires `rustc` >= 1.26.
+
 Requires `solc` to be in `$PATH`: [installation instructions.](https://solidity.readthedocs.io/en/develop/installing-solidity.html)
 
 Assuming you've cloned the bridge (`git clone git@github.com:poanetwork/poa-bridge.git`), run
@@ -82,6 +84,9 @@ rpc_host = "http://localhost"
 rpc_port = 8545
 required_confirmations = 0
 password = "home_password.txt"
+gas_price_oracle_url = "https://gasprice.poa.network"
+gas_price_speed = "instant"
+default_gas_price = 10000000000 # 10 GWEI
 
 [foreign]
 account = "0x006e27b6a72e1f34c626762f3c4761547aff1421"
@@ -99,9 +104,9 @@ accounts = [
 required_signatures = 2
 
 [transactions]
-deposit_relay = { gas = 3000000, gas_price = 1000000000 }
-withdraw_relay = { gas = 3000000, gas_price = 1000000000 }
-withdraw_confirm = { gas = 3000000, gas_price = 1000000000 }
+deposit_relay = { gas = 3000000 }
+withdraw_relay = { gas = 3000000 }
+withdraw_confirm = { gas = 3000000 }
 ```
 
 #### Options
@@ -130,13 +135,10 @@ withdraw_confirm = { gas = 3000000, gas_price = 1000000000 }
 #### transaction options
 
 - `transaction.deposit_relay.gas` - specify how much gas should be consumed by deposit relay
-- `transaction.deposit_relay.gas_price` - specify gas price for deposit relay
 - `transaction.deposit_relay.concurrency` - how many concurrent transactions can be sent (default: **100**)
 - `transaction.withdraw_confirm.gas` - specify how much gas should be consumed by withdraw confirm
-- `transaction.withdraw_confirm.gas_price` - specify gas price for withdraw confirm
 - `transaction.withdraw_confirm.concurrency` - how many concurrent transactions can be sent (default: **100**)
 - `transaction.withdraw_relay.gas` - specify how much gas should be consumed by withdraw relay
-- `transaction.withdraw_relay.gas_price` - specify gas price for withdraw relay
 - `transaction.withdraw_relay.concurrency` - how many concurrent transactions can be sent (default: **100**)
 
 ### Database file format

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ and they can convert them back as well.
 
 Requires `rust` and `cargo`: [installation instructions.](https://www.rust-lang.org/en-US/install.html)
 
-Requires `rustc` >= 1.26.
-
 Requires `solc` to be in `$PATH`: [installation instructions.](https://solidity.readthedocs.io/en/develop/installing-solidity.html)
 
 Assuming you've cloned the bridge (`git clone git@github.com:poanetwork/poa-bridge.git`), run
@@ -86,7 +84,7 @@ required_confirmations = 0
 password = "home_password.txt"
 gas_price_oracle_url = "https://gasprice.poa.network"
 gas_price_speed = "instant"
-default_gas_price = 10000000000 # 10 GWEI
+default_gas_price = 10_000_000_000 # 10 GWEI
 
 [foreign]
 account = "0x006e27b6a72e1f34c626762f3c4761547aff1421"

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -6,12 +6,16 @@ required_confirmations = 0
 rpc_host = "http://rpc.host.for.home"
 rpc_port = 8545
 password = "home_password.txt"
+gas_price_oracle_url = "https://gasprice.poa.network"
+gas_price_speed = "instant"
+default_gas_price = 10000000000 # 10 GWEI
 
 [foreign]
 account = "0x006e27b6a72e1f34c626762f3c4761547aff1421"
 required_confirmations = 0
 rpc_host = "https://rpc.host.for.foreign"
 rpc_port = 443
+default_gas_price = 5000000000 # 5 GWEI
 
 [authorities]
 accounts = [
@@ -20,6 +24,6 @@ accounts = [
 required_signatures = 1
 
 [transactions]
-home_deploy = { gas = 1000000, gas_price = 1000000000 }
-foreign_deploy = { gas = 3000000, gas_price = 1000000000 }
-deposit_relay = { gas = 100000, gas_price = 1000000000 }
+home_deploy = { gas = 1000000 }
+foreign_deploy = { gas = 3000000 }
+deposit_relay = { gas = 100000 }

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -8,14 +8,14 @@ rpc_port = 8545
 password = "home_password.txt"
 gas_price_oracle_url = "https://gasprice.poa.network"
 gas_price_speed = "instant"
-default_gas_price = 10000000000 # 10 GWEI
+default_gas_price = 10_000_000_000 # 10 GWEI
 
 [foreign]
 account = "0x006e27b6a72e1f34c626762f3c4761547aff1421"
 required_confirmations = 0
 rpc_host = "https://rpc.host.for.foreign"
 rpc_port = 443
-default_gas_price = 5000000000 # 5 GWEI
+default_gas_price = 5_000_000_000 # 5 GWEI
 
 [authorities]
 accounts = [


### PR DESCRIPTION
**Problem**: the readme and example config TOML files include obsolete gas-price config options.

**Solution**: remove the old config options, document the new gas-price config options.