### PR TITLE
Problem: not enforcing a minimum required rustc version could lead to build-time errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "quickcheck 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.1 (git+http://github.com/paritytech/parity?rev=991f0ca)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/bridge/Cargo.toml
+++ b/bridge/Cargo.toml
@@ -32,6 +32,9 @@ hyper-tls = "0.1.3"
 tempdir = "0.3"
 quickcheck = "0.6.1"
 
+[build-dependencies]
+rustc_version = "0.2.2"
+
 [features]
 default = []
 deploy = []

--- a/bridge/build.rs
+++ b/bridge/build.rs
@@ -1,6 +1,27 @@
+extern crate rustc_version;
+
 use std::process::Command;
 
+use rustc_version::{version as get_rustc_version, Version};
+
+fn check_rustc_version() {
+	let minimum_required_version = Version::new(1, 26, 0);
+
+    if let Ok(version) = get_rustc_version() {
+        if version < minimum_required_version {
+			panic!(
+				"Invalid rustc version, `poa-bridge` requires \
+				rustc >= {}, found version: {}",
+				minimum_required_version,
+				version
+			);
+		}
+	}
+}
+
 fn main() {
+	check_rustc_version();
+
 	// rerun build script if bridge contract has changed.
 	// without this cargo doesn't since the bridge contract
 	// is outside the crate directories


### PR DESCRIPTION
**Problem**: not enforcing a minimum required rustc version could lead to build-time errors.

**Solution**: add a mechanism to enforce a minimum required rustc version in the bridge's build script.