### PR TITLE
Problem: authorities.accounts config setting is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,6 @@ required_confirmations = 0
 password = "foreign_password.txt"
 
 [authorities]
-accounts = [
-    "0x006e27b6a72e1f34c626762f3c4761547aff1421",
-    "0x006e27b6a72e1f34c626762f3c4761547aff1421",
-    "0x006e27b6a72e1f34c626762f3c4761547aff1421"
-]
 required_signatures = 2
 
 [transactions]

--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -50,6 +50,7 @@ impl Config {
 			home: Node::from_load_struct(config.home)?,
 			foreign: Node::from_load_struct(config.foreign)?,
 			authorities: Authorities {
+				#[cfg(feature = "deploy")]
 				accounts: config.authorities.accounts,
 				required_signatures: config.authorities.required_signatures,
 			},
@@ -206,6 +207,7 @@ pub struct ContractConfig {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Authorities {
+	#[cfg(feature = "deploy")]
 	pub accounts: Vec<Address>,
 	pub required_signatures: u32,
 }
@@ -305,8 +307,9 @@ mod load {
 	}
 
 	#[derive(Deserialize)]
-	#[serde(deny_unknown_fields)]
 	pub struct Authorities {
+		#[cfg(feature = "deploy")]
+		#[serde(default)]
 		pub accounts: Vec<Address>,
 		pub required_signatures: u32,
 	}
@@ -351,11 +354,6 @@ password = "password"
 bin = "../compiled_contracts/ForeignBridge.bin"
 
 [authorities]
-accounts = [
-	"0x0000000000000000000000000000000000000001",
-	"0x0000000000000000000000000000000000000002",
-	"0x0000000000000000000000000000000000000003"
-]
 required_signatures = 2
 
 [transactions]
@@ -402,10 +400,8 @@ home_deploy = { gas = 20 }
 				default_gas_price: DEFAULT_GAS_PRICE_WEI,
 			},
 			authorities: Authorities {
+				#[cfg(feature = "deploy")]
 				accounts: vec![
-					"0000000000000000000000000000000000000001".into(),
-					"0000000000000000000000000000000000000002".into(),
-					"0000000000000000000000000000000000000003".into(),
 				],
 				required_signatures: 2,
 			},
@@ -449,11 +445,6 @@ password = "password"
 bin = "../compiled_contracts/ForeignBridge.bin"
 
 [authorities]
-accounts = [
-	"0x0000000000000000000000000000000000000001",
-	"0x0000000000000000000000000000000000000002",
-	"0x0000000000000000000000000000000000000003"
-]
 required_signatures = 2
 "#;
 		let expected = Config {
@@ -495,10 +486,8 @@ required_signatures = 2
 				default_gas_price: DEFAULT_GAS_PRICE_WEI,
 			},
 			authorities: Authorities {
+				#[cfg(feature = "deploy")]
 				accounts: vec![
-					"0000000000000000000000000000000000000001".into(),
-					"0000000000000000000000000000000000000002".into(),
-					"0000000000000000000000000000000000000003".into(),
 				],
 				required_signatures: 2,
 			},

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -14,9 +14,6 @@ rpc_host = "https://rpc.host.for.foreign"
 rpc_port = 443
 
 [authorities]
-accounts = [
-	"0x006e27b6a72e1f34c626762f3c4761547aff1421",
-]
 required_signatures = 1
 
 [transactions]


### PR DESCRIPTION
Solution: make it only accessible when `deploy` feature is on
(for integration tests)