### PR TITLE
Problem: hard to check which version the bridge is

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2752,6 +2753,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "version"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "version_check"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3221,6 +3227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum vecio 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0795a11576d29ae80525a3fda315bf7b534f8feb9d34101e5fe63fb95bb2fd24"
+"checksum version 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3a449064fee414fcc201356a3e6c1510f6c8829ed28bb06b91c54ebe208ce065"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 "checksum vm 0.1.0 (git+http://github.com/paritytech/parity?rev=991f0ca)" = "<none>"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = "0.4"
 futures = "0.1.14"
 jsonrpc-core = "8.0"
 ctrlc = { version = "3.1", features = ["termination"] }
+version = "3"
 
 [features]
 default = []

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,12 @@
+use std::process::Command;
+
+fn main() {
+	let cmd = Command::new("git").args(&["describe", "--long", "--tags", "--always", "--dirty=-modified"]).output().unwrap();
+	if cmd.status.success() {
+		// if we're successful, use this as a version
+		let ver = std::str::from_utf8(&cmd.stdout[1..]).unwrap().trim(); // drop "v" in the front
+		println!("cargo:rustc-env={}={}", "CARGO_PKG_VERSION", ver);
+	}
+	// otherwise, whatever is specified in Cargo manifest
+	println!("cargo:rerun-if-changed=nonexistentfile"); // always rerun build.rs
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,6 +10,8 @@ extern crate env_logger;
 extern crate bridge;
 extern crate ctrlc;
 extern crate jsonrpc_core as rpc;
+#[macro_use]
+extern crate version;
 
 use std::{env, fs, io};
 use std::sync::Arc;
@@ -73,15 +75,18 @@ POA-Ethereum bridge.
 Usage:
     bridge --config <config> --database <database>
     bridge -h | --help
+    bridge -v | --version
 
 Options:
     -h, --help           Display help message and exit.
+    -v, --version        Print version and exit.
 "#;
 
 #[derive(Debug, Deserialize)]
 pub struct Args {
 	arg_config: PathBuf,
 	arg_database: PathBuf,
+	flag_version: bool,
 }
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -117,6 +122,10 @@ fn execute<S, I>(command: I, running: Arc<AtomicBool>) -> Result<String, UserFac
 	info!(target: "bridge", "Parsing cli arguments");
 	let args: Args = Docopt::new(USAGE)
 		.and_then(|d| d.argv(command).deserialize()).map_err(|e| e.to_string())?;
+
+	if args.flag_version {
+		return Ok(version!().into())
+	}
 
 	info!(target: "bridge", "Loading config");
 	let config = Config::load(args.arg_config)?;


### PR DESCRIPTION
Solution: introduce `bridge -v|--version` flag to print the version

The version is built off `git describe`, however, as a backup,
if `git describe` fails (stripped .git, etc.), this will fall back
to whatever is specified in Cargo.toml

Fixes #87