### PR TITLE
Problem: gas price configuration in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,16 @@ rpc_host = "http://localhost"
 rpc_port = 8545
 required_confirmations = 0
 password = "home_password.txt"
-gas_price_oracle_url = "https://gasprice.poa.network"
-gas_price_speed = "instant"
-default_gas_price = 10_000_000_000 # 10 GWEI
+default_gas_price = 1_000_000_000 # 1 GWEI
 
 [foreign]
 account = "0x006e27b6a72e1f34c626762f3c4761547aff1421"
 rpc_host = "http://localhost"
 rpc_port = 9545
 required_confirmations = 0
+gas_price_oracle_url = "https://gasprice.poa.network"
+gas_price_speed = "instant"
+default_gas_price = 10_000_000_000 # 10 GWEI
 password = "foreign_password.txt"
 
 [authorities]

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -6,9 +6,7 @@ required_confirmations = 0
 rpc_host = "http://rpc.host.for.home"
 rpc_port = 8545
 password = "home_password.txt"
-gas_price_oracle_url = "https://gasprice.poa.network"
-gas_price_speed = "instant"
-default_gas_price = 10_000_000_000 # 10 GWEI
+default_gas_price = 1_000_000_000 # 1 GWEI
 
 [foreign]
 account = "0x006e27b6a72e1f34c626762f3c4761547aff1421"
@@ -16,6 +14,10 @@ required_confirmations = 0
 rpc_host = "https://rpc.host.for.foreign"
 rpc_port = 443
 default_gas_price = 5_000_000_000 # 5 GWEI
+gas_price_oracle_url = "https://gasprice.poa.network"
+gas_price_speed = "instant"
+default_gas_price = 10_000_000_000 # 10 GWEI
+
 
 [authorities]
 required_signatures = 1


### PR DESCRIPTION
It's confusing that gas price oracle is used on the
home side of the bridge, as opposed to the foreign one,
because gas price is fixed on POA.

Solution: flip the gas price configuration example between sides