### PR TITLE
Problem: hard-coded transaction gas

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,6 @@ password = "foreign_password.txt"
 
 [authorities]
 required_signatures = 2
-
-[transactions]
-deposit_relay = { gas = 3000000 }
-withdraw_relay = { gas = 3000000 }
-withdraw_confirm = { gas = 3000000 }
 ```
 
 #### Options
@@ -133,9 +128,9 @@ withdraw_confirm = { gas = 3000000 }
 
 #### transaction options
 
-- `transaction.deposit_relay.gas` - specify how much gas should be consumed by deposit relay
-- `transaction.withdraw_confirm.gas` - specify how much gas should be consumed by withdraw confirm
-- `transaction.withdraw_relay.gas` - specify how much gas should be consumed by withdraw relay
+- `transaction.deposit_relay.gas` - specify how much gas should be consumed by deposit relay (optional, default: computed with `eth.estimateGas`)
+- `transaction.withdraw_confirm.gas` - specify how much gas should be consumed by withdraw confirm (optional, default: computed with `eth.estimateGas`)
+- `transaction.withdraw_relay.gas` - specify how much gas should be consumed by withdraw relay (optional, default: computed with `eth.estimateGas`)
 
 ### Database file format
 

--- a/bridge/src/api.rs
+++ b/bridge/src/api.rs
@@ -142,6 +142,24 @@ pub fn call<T: Transport>(transport: T, address: Address, payload: Bytes) -> Api
 	}
 }
 
+/// Imperative wrapper for web3 function.
+pub fn estimate_gas<T: Transport>(transport: T, sender: Option<Address>, address: Address, payload: Bytes) -> ApiCall<U256, T::Out> {
+	let future = api::Eth::new(transport).estimate_gas(CallRequest {
+		from: sender,
+		to: address,
+		gas: None,
+		gas_price: None,
+		value: None,
+		data: Some(payload),
+	}, None);
+
+	ApiCall {
+		future,
+		message: "eth_estimateGas",
+	}
+}
+
+
 /// Returns a eth_sign-compatible hash of data to sign.
 /// The data is prepended with special message to prevent
 /// chosen-plaintext attacks.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -19,8 +19,3 @@ default_gas_price = 5_000_000_000 # 5 GWEI
 
 [authorities]
 required_signatures = 1
-
-[transactions]
-home_deploy = { gas = 1000000 }
-foreign_deploy = { gas = 3000000 }
-deposit_relay = { gas = 100000 }

--- a/integration-tests/bridge_config.toml
+++ b/integration-tests/bridge_config.toml
@@ -33,6 +33,6 @@ required_signatures = 1
 [transactions]
 home_deploy = { gas = 3000000 }
 foreign_deploy = { gas = 3000000 }
-deposit_relay = { gas = 3000000 }
-withdraw_relay = { gas = 3000000 }
-withdraw_confirm = { gas = 3000000 }
+#deposit_relay = { gas = 3000000 }
+#withdraw_relay = { gas = 3000000 }
+#withdraw_confirm = { gas = 3000000 }


### PR DESCRIPTION
This makes it very to make a mistake when configuring
the bridge and have failing transactions as a result.

Solution: use `eth.estimateGas` call for every transaction

Configuration values for `gas` will be only used if they
are set and non-zero.

If `estimateGas` fails, the transaction will be thrown out
as it will be assumed that it is failing and therefore we
shouldn't waste resources on it.