### PR TITLE
Move bridge contact addresses to primary configuration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ and they can convert them back as well.
 
 ![withdraw](./res/withdraw.png)
 
-### How to build 
+### How to build
 
 Requires `rust` and `cargo`: [installation instructions.](https://www.rust-lang.org/en-US/install.html)
 
@@ -83,6 +83,7 @@ keystore = "/path/to/keystore"
 
 [home]
 account = "0x006e27b6a72e1f34c626762f3c4761547aff1421"
+contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db7"
 rpc_host = "http://localhost"
 rpc_port = 8545
 required_confirmations = 0
@@ -91,6 +92,7 @@ default_gas_price = 1_000_000_000 # 1 GWEI
 
 [foreign]
 account = "0x006e27b6a72e1f34c626762f3c4761547aff1421"
+contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db8"
 rpc_host = "http://localhost"
 rpc_port = 9545
 required_confirmations = 0
@@ -110,11 +112,12 @@ withdraw_confirm = { gas = 3000000 }
 
 #### Options
 
-- `keystore` - path to a keystore directory with JSON keys  
+- `keystore` - path to a keystore directory with JSON keys
 
 #### home/foreign options
 
 - `home/foreign.account` - authority address on the home (**required**)
+- `home/foreign.contract_address` - The address of the bridge contract on home/foreign chain. (**required** unless the configuration is being used in a deploy build [FIXME: clarify this description]).
 - `home/foreign.rpc_host` - RPC host (**required**)
 - `home/foreign.rpc_port` - RPC port (**defaults to 8545**)
 - `home/foreign.required_confirmations` - number of confirmation required to consider transaction final on home (default: **12**)
@@ -141,8 +144,6 @@ withdraw_confirm = { gas = 3000000 }
 ### Database file format
 
 ```toml
-home_contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db7"
-foreign_contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db8"
 checked_deposit_relay = 120
 checked_withdraw_relay = 121
 checked_withdraw_confirm = 121
@@ -150,8 +151,6 @@ checked_withdraw_confirm = 121
 
 **all fields are required**
 
-- `home_contract_address` - address of the bridge contract on home chain
-- `foreign_contract_address` - address of the bridge contract on foreign chain
 - `checked_deposit_relay` - number of the last block for which an authority has relayed deposits to the foreign
 - `checked_withdraw_relay` - number of the last block for which an authority has relayed withdraws to the home
 - `checked_withdraw_confirm` - number of the last block for which an authority has confirmed withdraw

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ withdraw_confirm = { gas = 3000000 }
 #### home/foreign options
 
 - `home/foreign.account` - authority address on the home (**required**)
-- `home/foreign.contract_address` - The address of the bridge contract on home/foreign chain. (**required** unless the configuration is being used in a deploy build [FIXME: clarify this description]).
+- `home/foreign.contract_address` - The address of the bridge contract on home/foreign chain. (**required**).
 - `home/foreign.rpc_host` - RPC host (**required**)
 - `home/foreign.rpc_port` - RPC port (**defaults to 8545**)
 - `home/foreign.required_confirmations` - number of confirmation required to consider transaction final on home (default: **12**)

--- a/bridge/src/bridge/deploy.rs
+++ b/bridge/src/bridge/deploy.rs
@@ -22,7 +22,6 @@ pub enum Deployed {
 	Existing(Database),
 }
 
-// FIXME: Needs documentation. What do these states signify?
 #[cfg(feature = "deploy")]
 enum DeployState<T: Transport + Clone> {
 	CheckIfNeeded,

--- a/bridge/src/bridge/deposit_relay.rs
+++ b/bridge/src/bridge/deposit_relay.rs
@@ -49,11 +49,11 @@ pub fn create_deposit_relay<T: Transport + Clone>(app: Arc<App<T>>, init: &Datab
 		request_timeout: app.config.home.request_timeout,
 		poll_interval: app.config.home.poll_interval,
 		confirmations: app.config.home.required_confirmations,
-		filter: deposits_filter(&app.home_bridge, init.home_contract_address),
+		filter: deposits_filter(&app.home_bridge, app.config.home.contract_address),
 	};
 	DepositRelay {
 		logs: api::log_stream(app.connections.home.clone(), app.timer.clone(), logs_init),
-		foreign_contract: init.foreign_contract_address,
+		foreign_contract: app.config.foreign.contract_address,
 		state: DepositRelayState::Wait,
 		app,
 		foreign_balance,
@@ -92,7 +92,7 @@ impl<T: Transport> Stream for DepositRelay<T> {
 					let gas = U256::from(self.app.config.txs.deposit_relay.gas);
 					let gas_price = U256::from(*self.foreign_gas_price.read().unwrap());
 					let balance_required = gas * gas_price * U256::from(item.logs.len());
-					
+
 					if balance_required > *foreign_balance.as_ref().unwrap() {
 						return Err(ErrorKind::InsufficientFunds.into())
 					}

--- a/bridge/src/bridge/gas_price.rs
+++ b/bridge/src/bridge/gas_price.rs
@@ -165,7 +165,7 @@ mod tests {
 	fn errored_request() {
 		let node = Node {
 			account: Address::new(),
-			contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
+			contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db7".into(),
 			request_timeout: Duration::from_secs(5),
 			poll_interval: Duration::from_secs(1),
 			required_confirmations: 0,
@@ -209,7 +209,7 @@ mod tests {
 	fn bad_json() {
 		let node = Node {
 			account: Address::new(),
-			contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
+			contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db7".into(),
 			request_timeout: Duration::from_secs(5),
 			poll_interval: Duration::from_secs(1),
 			required_confirmations: 0,
@@ -253,7 +253,7 @@ mod tests {
 	fn unexpected_json() {
 		let node = Node {
 			account: Address::new(),
-			contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
+			contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db7".into(),
 			request_timeout: Duration::from_secs(5),
 			poll_interval: Duration::from_secs(1),
 			required_confirmations: 0,
@@ -296,7 +296,7 @@ mod tests {
 	fn non_object_json() {
 		let node = Node {
 			account: Address::new(),
-			contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
+			contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db7".into(),
 			request_timeout: Duration::from_secs(5),
 			poll_interval: Duration::from_secs(1),
 			required_confirmations: 0,
@@ -339,7 +339,7 @@ mod tests {
 	fn correct_json() {
 		let node = Node {
 			account: Address::new(),
-			contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
+			contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db7".into(),
 			request_timeout: Duration::from_secs(5),
 			poll_interval: Duration::from_secs(1),
 			required_confirmations: 0,

--- a/bridge/src/bridge/gas_price.rs
+++ b/bridge/src/bridge/gas_price.rs
@@ -165,6 +165,7 @@ mod tests {
 	fn errored_request() {
 		let node = Node {
 			account: Address::new(),
+			contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
 			request_timeout: Duration::from_secs(5),
 			poll_interval: Duration::from_secs(1),
 			required_confirmations: 0,
@@ -208,6 +209,7 @@ mod tests {
 	fn bad_json() {
 		let node = Node {
 			account: Address::new(),
+			contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
 			request_timeout: Duration::from_secs(5),
 			poll_interval: Duration::from_secs(1),
 			required_confirmations: 0,
@@ -251,6 +253,7 @@ mod tests {
 	fn unexpected_json() {
 		let node = Node {
 			account: Address::new(),
+			contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
 			request_timeout: Duration::from_secs(5),
 			poll_interval: Duration::from_secs(1),
 			required_confirmations: 0,
@@ -293,6 +296,7 @@ mod tests {
 	fn non_object_json() {
 		let node = Node {
 			account: Address::new(),
+			contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
 			request_timeout: Duration::from_secs(5),
 			poll_interval: Duration::from_secs(1),
 			required_confirmations: 0,
@@ -335,6 +339,7 @@ mod tests {
 	fn correct_json() {
 		let node = Node {
 			account: Address::new(),
+			contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
 			request_timeout: Duration::from_secs(5),
 			poll_interval: Duration::from_secs(1),
 			required_confirmations: 0,

--- a/bridge/src/bridge/mod.rs
+++ b/bridge/src/bridge/mod.rs
@@ -62,7 +62,7 @@ impl<ES: Stream<Item = BridgeChecked, Error = Error>> Stream for Bridge<ES> {
 			.create(true)
 			.open(&self.path)?;
 
-		self.database.save(file)?;
+		self.database.store(file)?;
 		Ok(Async::Ready(Some(())))
 	}
 }
@@ -221,6 +221,7 @@ impl<'a, T: Transport + 'a> Stream for BridgeEventStream<'a, T> {
 #[cfg(test)]
 mod tests {
 	extern crate tempdir;
+
 	use self::tempdir::TempDir;
 	use database::Database;
 	use super::{Bridge, BridgeChecked};
@@ -243,7 +244,8 @@ mod tests {
 		let mut event_loop = Core::new().unwrap();
 		let _ = event_loop.run(bridge.collect());
 
-		let db = Database::load(&path).unwrap();
+		let db = Database::load_stored(&path).unwrap();
+
 		assert_eq!(1, db.checked_deposit_relay);
 		assert_eq!(0, db.checked_withdraw_confirm);
 		assert_eq!(0, db.checked_withdraw_relay);
@@ -251,13 +253,15 @@ mod tests {
 		let bridge = Bridge {
 			path: path.clone(),
 			database: Database::default(),
-			event_stream: stream::iter_ok::<_, Error>(vec![BridgeChecked::DepositRelay(2), BridgeChecked::WithdrawConfirm(3), BridgeChecked::WithdrawRelay(2)]),
+			event_stream: stream::iter_ok::<_, Error>(vec![BridgeChecked::DepositRelay(2),
+				BridgeChecked::WithdrawConfirm(3), BridgeChecked::WithdrawRelay(2)]),
 		};
 
 		let mut event_loop = Core::new().unwrap();
 		let _ = event_loop.run(bridge.collect());
 
-		let db = Database::load(&path).unwrap();
+		let db = Database::load_stored(&path).unwrap();
+
 		assert_eq!(2, db.checked_deposit_relay);
 		assert_eq!(3, db.checked_withdraw_confirm);
 		assert_eq!(2, db.checked_withdraw_relay);

--- a/bridge/src/bridge/mod.rs
+++ b/bridge/src/bridge/mod.rs
@@ -62,7 +62,7 @@ impl<ES: Stream<Item = BridgeChecked, Error = Error>> Stream for Bridge<ES> {
 			.create(true)
 			.open(&self.path)?;
 
-		self.database.store(file)?;
+		self.database.save(file)?;
 		Ok(Async::Ready(Some(())))
 	}
 }
@@ -244,7 +244,7 @@ mod tests {
 		let mut event_loop = Core::new().unwrap();
 		let _ = event_loop.run(bridge.collect());
 
-		let db = Database::load_stored(&path).unwrap();
+		let db = Database::load(&path).unwrap();
 
 		assert_eq!(1, db.checked_deposit_relay);
 		assert_eq!(0, db.checked_withdraw_confirm);
@@ -260,7 +260,7 @@ mod tests {
 		let mut event_loop = Core::new().unwrap();
 		let _ = event_loop.run(bridge.collect());
 
-		let db = Database::load_stored(&path).unwrap();
+		let db = Database::load(&path).unwrap();
 
 		assert_eq!(2, db.checked_deposit_relay);
 		assert_eq!(3, db.checked_withdraw_confirm);

--- a/bridge/src/bridge/withdraw_confirm.rs
+++ b/bridge/src/bridge/withdraw_confirm.rs
@@ -44,12 +44,12 @@ pub fn create_withdraw_confirm<T: Transport + Clone>(app: Arc<App<T>>, init: &Da
 		request_timeout: app.config.foreign.request_timeout,
 		poll_interval: app.config.foreign.poll_interval,
 		confirmations: app.config.foreign.required_confirmations,
-		filter: withdraws_filter(&app.foreign_bridge, init.foreign_contract_address.clone()),
+		filter: withdraws_filter(&app.foreign_bridge, app.config.foreign.contract_address.clone()),
 	};
 
 	WithdrawConfirm {
 		logs: api::log_stream(app.connections.foreign.clone(), app.timer.clone(), logs_init),
-		foreign_contract: init.foreign_contract_address,
+		foreign_contract: app.config.foreign.contract_address,
 		state: WithdrawConfirmState::Wait,
 		app,
 		foreign_balance,

--- a/bridge/src/bridge/withdraw_relay.rs
+++ b/bridge/src/bridge/withdraw_relay.rs
@@ -83,13 +83,13 @@ pub fn create_withdraw_relay<T: Transport + Clone>(app: Arc<App<T>>, init: &Data
 		request_timeout: app.config.foreign.request_timeout,
 		poll_interval: app.config.foreign.poll_interval,
 		confirmations: app.config.foreign.required_confirmations,
-		filter: collected_signatures_filter(&app.foreign_bridge, init.foreign_contract_address),
+		filter: collected_signatures_filter(&app.foreign_bridge, app.config.foreign.contract_address),
 	};
 
 	WithdrawRelay {
 		logs: api::log_stream(app.connections.foreign.clone(), app.timer.clone(), logs_init),
-		home_contract: init.home_contract_address,
-		foreign_contract: init.foreign_contract_address,
+		home_contract: app.config.home.contract_address,
+		foreign_contract: app.config.foreign.contract_address,
 		state: WithdrawRelayState::Wait,
 		app,
 		home_balance,

--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -161,9 +161,10 @@ impl Node {
 
 		// Ensure that the contract address is specified for non-deploy builds:
 		if cfg!(not(feature = "deploy")) && node.contract_address.is_none() {
-			return Err("Contract address not specified. Please define the 'contract_address' \
-				key within both the '[home]' and '[foreign]' tables in the toml config file. \
-				See 'https://github.com/poanetwork/poa-bridge/blob/master/README.md' for more.".into())
+			return Err(ErrorKind::ConfigError("Contract address not specified. Please define the \
+				'contract_address' key within both the '[home]' and '[foreign]' tables in the \
+				toml config file. See 'https://github.com/poanetwork/poa-bridge/blob/master/README.md' \
+				for more.".into()).into());
 		}
 
 		Ok(node)

--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -41,11 +41,11 @@ impl Config {
 	}
 
 	fn load_from_str(s: &str, allow_insecure_rpc_endpoints: bool) -> Result<Config, Error> {
-		let config: parsed::Config = toml::from_str(s).chain_err(|| "Cannot parse config")?;
+		let config: parse::Config = toml::from_str(s).chain_err(|| "Cannot parse config")?;
 		Config::from_load_struct(config, allow_insecure_rpc_endpoints)
 	}
 
-	fn from_load_struct(config: parsed::Config, allow_insecure_rpc_endpoints: bool) -> Result<Config, Error> {
+	fn from_load_struct(config: parse::Config, allow_insecure_rpc_endpoints: bool) -> Result<Config, Error> {
 		let config = Config {
 			home: Node::from_load_struct(config.home, allow_insecure_rpc_endpoints)?,
 			foreign: Node::from_load_struct(config.foreign, allow_insecure_rpc_endpoints)?,
@@ -107,7 +107,7 @@ impl PartialEq for NodeInfo {
 }
 
 impl Node {
-	fn from_load_struct(node: parsed::Node, allow_insecure_rpc_endpoints: bool) -> Result<Node, Error> {
+	fn from_load_struct(node: parse::Node, allow_insecure_rpc_endpoints: bool) -> Result<Node, Error> {
 		let gas_price_oracle_url = node.gas_price_oracle_url.clone();
 
 		let gas_price_speed = match node.gas_price_speed {
@@ -190,7 +190,7 @@ pub struct Transactions {
 }
 
 impl Transactions {
-	fn from_load_struct(cfg: parsed::Transactions) -> Self {
+	fn from_load_struct(cfg: parse::Transactions) -> Self {
 		Transactions {
 			#[cfg(feature = "deploy")]
 			home_deploy: cfg.home_deploy.map(TransactionConfig::from_load_struct).unwrap_or_default(),
@@ -210,7 +210,7 @@ pub struct TransactionConfig {
 }
 
 impl TransactionConfig {
-	fn from_load_struct(cfg: parsed::TransactionConfig) -> Self {
+	fn from_load_struct(cfg: parse::TransactionConfig) -> Self {
 		TransactionConfig {
 			gas: cfg.gas.unwrap_or_default(),
 			gas_price: cfg.gas_price.unwrap_or_default(),
@@ -268,7 +268,7 @@ impl GasPriceSpeed {
 /// Some config values may not be defined in `toml` file, but they should be specified at runtime.
 /// `load` module separates `Config` representation in file with optional from the one used
 /// in application.
-mod parsed {
+mod parse {
 	use std::path::PathBuf;
 	use web3::types::Address;
 

--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -41,12 +41,12 @@ impl Config {
 	}
 
 	fn load_from_str(s: &str, allow_insecure_rpc_endpoints: bool) -> Result<Config, Error> {
-		let config: load::Config = toml::from_str(s).chain_err(|| "Cannot parse config")?;
+		let config: parsed::Config = toml::from_str(s).chain_err(|| "Cannot parse config")?;
 		Config::from_load_struct(config, allow_insecure_rpc_endpoints)
 	}
 
-	fn from_load_struct(config: load::Config, allow_insecure_rpc_endpoints: bool) -> Result<Config, Error> {
-		let result = Config {
+	fn from_load_struct(config: parsed::Config, allow_insecure_rpc_endpoints: bool) -> Result<Config, Error> {
+		let config = Config {
 			home: Node::from_load_struct(config.home, allow_insecure_rpc_endpoints)?,
 			foreign: Node::from_load_struct(config.foreign, allow_insecure_rpc_endpoints)?,
 			authorities: Authorities {
@@ -60,7 +60,7 @@ impl Config {
 			keystore: config.keystore,
 		};
 
-		Ok(result)
+		Ok(config)
 	}
 }
 
@@ -69,6 +69,7 @@ pub struct Node {
 	pub account: Address,
 	#[cfg(feature = "deploy")]
 	pub contract: ContractConfig,
+	pub contract_address: Option<Address>,
 	pub request_timeout: Duration,
 	pub poll_interval: Duration,
 	pub required_confirmations: usize,
@@ -106,7 +107,7 @@ impl PartialEq for NodeInfo {
 }
 
 impl Node {
-	fn from_load_struct(node: load::Node, allow_insecure_rpc_endpoints: bool) -> Result<Node, Error> {
+	fn from_load_struct(node: parsed::Node, allow_insecure_rpc_endpoints: bool) -> Result<Node, Error> {
 		let gas_price_oracle_url = node.gas_price_oracle_url.clone();
 
 		let gas_price_speed = match node.gas_price_speed {
@@ -132,7 +133,7 @@ impl Node {
 			}
 		}
 
-		let result = Node {
+		let node = Node {
 			account: node.account,
 			#[cfg(feature = "deploy")]
 			contract: ContractConfig {
@@ -143,6 +144,7 @@ impl Node {
 					Bytes(read.from_hex()?)
 				}
 			},
+			contract_address: node.contract_address,
 			request_timeout: Duration::from_secs(node.request_timeout.unwrap_or(DEFAULT_TIMEOUT)),
 			poll_interval: Duration::from_secs(node.poll_interval.unwrap_or(DEFAULT_POLL_INTERVAL)),
 			required_confirmations: node.required_confirmations.unwrap_or(DEFAULT_CONFIRMATIONS),
@@ -157,7 +159,14 @@ impl Node {
 			concurrent_http_requests,
 		};
 
-		Ok(result)
+		// Ensure that the contract address is specified for non-deploy builds:
+		if cfg!(not(feature = "deploy")) && node.contract_address.is_none() {
+			return Err("Contract address not specified. Please define the 'contract_address' \
+				key within both the '[home]' and '[foreign]' tables in the toml config file. \
+				See 'https://github.com/poanetwork/poa-bridge/blob/master/README.md' for more.".into())
+		}
+
+		Ok(node)
 	}
 
 	pub fn password(&self) -> Result<String, Error> {
@@ -182,7 +191,7 @@ pub struct Transactions {
 }
 
 impl Transactions {
-	fn from_load_struct(cfg: load::Transactions) -> Self {
+	fn from_load_struct(cfg: parsed::Transactions) -> Self {
 		Transactions {
 			#[cfg(feature = "deploy")]
 			home_deploy: cfg.home_deploy.map(TransactionConfig::from_load_struct).unwrap_or_default(),
@@ -202,7 +211,7 @@ pub struct TransactionConfig {
 }
 
 impl TransactionConfig {
-	fn from_load_struct(cfg: load::TransactionConfig) -> Self {
+	fn from_load_struct(cfg: parsed::TransactionConfig) -> Self {
 		TransactionConfig {
 			gas: cfg.gas.unwrap_or_default(),
 			gas_price: cfg.gas_price.unwrap_or_default(),
@@ -260,7 +269,7 @@ impl GasPriceSpeed {
 /// Some config values may not be defined in `toml` file, but they should be specified at runtime.
 /// `load` module separates `Config` representation in file with optional from the one used
 /// in application.
-mod load {
+mod parsed {
 	use std::path::PathBuf;
 	use web3::types::Address;
 
@@ -282,6 +291,7 @@ mod load {
 		pub account: Address,
 		#[cfg(feature = "deploy")]
 		pub contract: ContractConfig,
+		pub contract_address: Option<Address>,
 		pub request_timeout: Option<u64>,
 		pub poll_interval: Option<u64>,
 		pub required_confirmations: Option<usize>,
@@ -348,6 +358,7 @@ keystore = "/keys"
 
 [home]
 account = "0x1B68Cb0B50181FC4006Ce572cF346e596E51818b"
+contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db7"
 poll_interval = 2
 required_confirmations = 100
 rpc_host = "127.0.0.1"
@@ -356,6 +367,7 @@ password = "password"
 
 [foreign]
 account = "0x0000000000000000000000000000000000000001"
+contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db8"
 rpc_host = "127.0.0.1"
 rpc_port = 8545
 password = "password"
@@ -371,6 +383,7 @@ required_signatures = 2
 			txs: Transactions::default(),
 			home: Node {
 				account: "1B68Cb0B50181FC4006Ce572cF346e596E51818b".into(),
+				contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
 				poll_interval: Duration::from_secs(2),
 				request_timeout: Duration::from_secs(DEFAULT_TIMEOUT),
 				required_confirmations: 100,
@@ -386,6 +399,7 @@ required_signatures = 2
 			},
 			foreign: Node {
 				account: "0000000000000000000000000000000000000001".into(),
+				contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db8".into()),
 				poll_interval: Duration::from_secs(1),
 				request_timeout: Duration::from_secs(DEFAULT_TIMEOUT),
 				required_confirmations: 12,
@@ -419,11 +433,13 @@ keystore = "/keys/"
 
 [home]
 account = "0x1B68Cb0B50181FC4006Ce572cF346e596E51818b"
+contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db7"
 rpc_host = ""
 password = "password"
 
 [foreign]
 account = "0x0000000000000000000000000000000000000001"
+contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db8"
 rpc_host = ""
 password = "password"
 
@@ -434,6 +450,7 @@ required_signatures = 2
 			txs: Transactions::default(),
 			home: Node {
 				account: "1B68Cb0B50181FC4006Ce572cF346e596E51818b".into(),
+				contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
 				poll_interval: Duration::from_secs(1),
 				request_timeout: Duration::from_secs(DEFAULT_TIMEOUT),
 				required_confirmations: 12,
@@ -449,6 +466,7 @@ required_signatures = 2
 			},
 			foreign: Node {
 				account: "0000000000000000000000000000000000000001".into(),
+				contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db8".into()),
 				poll_interval: Duration::from_secs(1),
 				request_timeout: Duration::from_secs(DEFAULT_TIMEOUT),
 				required_confirmations: 12,

--- a/bridge/src/config.rs
+++ b/bridge/src/config.rs
@@ -69,7 +69,7 @@ pub struct Node {
 	pub account: Address,
 	#[cfg(feature = "deploy")]
 	pub contract: ContractConfig,
-	pub contract_address: Option<Address>,
+	pub contract_address: Address,
 	pub request_timeout: Duration,
 	pub poll_interval: Duration,
 	pub required_confirmations: usize,
@@ -133,6 +133,12 @@ impl Node {
 			}
 		}
 
+		let contract_address = node.contract_address.ok_or(ErrorKind::ConfigError(
+				"Contract address not specified. Please define the 'contract_address' key \
+				within both the '[home]' and '[foreign]' tables in the toml config file. See \
+				'https://github.com/poanetwork/poa-bridge/blob/master/README.md' \
+				for more.".to_owned()))?;
+
 		let node = Node {
 			account: node.account,
 			#[cfg(feature = "deploy")]
@@ -144,7 +150,7 @@ impl Node {
 					Bytes(read.from_hex()?)
 				}
 			},
-			contract_address: node.contract_address,
+			contract_address: contract_address,
 			request_timeout: Duration::from_secs(node.request_timeout.unwrap_or(DEFAULT_TIMEOUT)),
 			poll_interval: Duration::from_secs(node.poll_interval.unwrap_or(DEFAULT_POLL_INTERVAL)),
 			required_confirmations: node.required_confirmations.unwrap_or(DEFAULT_CONFIRMATIONS),
@@ -158,14 +164,6 @@ impl Node {
 			default_gas_price,
 			concurrent_http_requests,
 		};
-
-		// Ensure that the contract address is specified for non-deploy builds:
-		if cfg!(not(feature = "deploy")) && node.contract_address.is_none() {
-			return Err(ErrorKind::ConfigError("Contract address not specified. Please define the \
-				'contract_address' key within both the '[home]' and '[foreign]' tables in the \
-				toml config file. See 'https://github.com/poanetwork/poa-bridge/blob/master/README.md' \
-				for more.".into()).into());
-		}
 
 		Ok(node)
 	}
@@ -384,7 +382,7 @@ required_signatures = 2
 			txs: Transactions::default(),
 			home: Node {
 				account: "1B68Cb0B50181FC4006Ce572cF346e596E51818b".into(),
-				contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
+				contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db7".into(),
 				poll_interval: Duration::from_secs(2),
 				request_timeout: Duration::from_secs(DEFAULT_TIMEOUT),
 				required_confirmations: 100,
@@ -400,7 +398,7 @@ required_signatures = 2
 			},
 			foreign: Node {
 				account: "0000000000000000000000000000000000000001".into(),
-				contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db8".into()),
+				contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db8".into(),
 				poll_interval: Duration::from_secs(1),
 				request_timeout: Duration::from_secs(DEFAULT_TIMEOUT),
 				required_confirmations: 12,
@@ -451,7 +449,7 @@ required_signatures = 2
 			txs: Transactions::default(),
 			home: Node {
 				account: "1B68Cb0B50181FC4006Ce572cF346e596E51818b".into(),
-				contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db7".into()),
+				contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db7".into(),
 				poll_interval: Duration::from_secs(1),
 				request_timeout: Duration::from_secs(DEFAULT_TIMEOUT),
 				required_confirmations: 12,
@@ -467,7 +465,7 @@ required_signatures = 2
 			},
 			foreign: Node {
 				account: "0000000000000000000000000000000000000001".into(),
-				contract_address: Some("49edf201c1e139282643d5e7c6fb0c7219ad1db8".into()),
+				contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db8".into(),
 				poll_interval: Duration::from_secs(1),
 				request_timeout: Duration::from_secs(DEFAULT_TIMEOUT),
 				required_confirmations: 12,

--- a/bridge/src/database.rs
+++ b/bridge/src/database.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 use std::{io, str, fs, fmt};
 use std::io::{Read, Write};
-use web3::types::Address;
 use toml;
 use error::{Error, ResultExt, ErrorKind};
 
@@ -9,10 +8,6 @@ use error::{Error, ResultExt, ErrorKind};
 /// Application "database".
 #[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
 pub struct Database {
-	/// Address of home contract.
-	pub home_contract_address: Address,
-	/// Address of foreign contract.
-	pub foreign_contract_address: Address,
 	/// Number of block at which home contract has been deployed.
 	pub home_deploy: Option<u64>,
 	/// Number of block at which foreign contract has been deployed.
@@ -25,20 +20,6 @@ pub struct Database {
 	pub checked_withdraw_confirm: u64,
 }
 
-impl From<parsed::StoredDatabase> for Database {
-	fn from(db_parsed: parsed::StoredDatabase) -> Database {
-		Database {
-			home_contract_address: db_parsed.home_contract_address,
-			foreign_contract_address: db_parsed.foreign_contract_address,
-			home_deploy: db_parsed.home_deploy,
-			foreign_deploy: db_parsed.foreign_deploy,
-			checked_deposit_relay: db_parsed.checked_deposit_relay,
-			checked_withdraw_relay: db_parsed.checked_withdraw_relay,
-			checked_withdraw_confirm: db_parsed.checked_withdraw_confirm,
-		}
-	}
-}
-
 impl fmt::Display for Database {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str(&toml::to_string(self).expect("serialization can't fail; qed"))
@@ -46,33 +27,9 @@ impl fmt::Display for Database {
 }
 
 impl Database {
-	/// Loads the toml file specified by `path` and returns a new `Database`
-	/// containing its parsed contents.
-	#[deprecated(note = "Use '::load_stored' instead.")]
-	pub fn load<P: AsRef<Path>>(path: P) -> Result<Database, Error> {
-		Self::load_stored(path)
-	}
-
-	/// Loads the toml file specified by `path` and returns a new `Database`
-	/// containing its parsed contents.
-	pub fn load_stored<P: AsRef<Path>>(path: P) -> Result<Database, Error> {
-		let mut file = match fs::File::open(&path) {
-			Ok(file) => file,
-			Err(ref err) if err.kind() == io::ErrorKind::NotFound =>
-				return Err(ErrorKind::MissingFile(format!("{:?}", path.as_ref())).into()),
-			Err(err) => return Err(err).chain_err(|| "Cannot open database file"),
-		};
-
-		let mut buffer = String::new();
-		file.read_to_string(&mut buffer)?;
-		Ok(toml::from_str::<parsed::StoredDatabase>(&buffer)?.into())
-
-	}
-
 	/// Loads a user defined toml file specified by `path` and returns a new
 	/// `Database` containing its parsed contents.
-	pub fn load_user_defined<P: AsRef<Path>>(path: P, home_contract_address: Address,
-			foreign_contract_address: Address)
+	pub fn load<P: AsRef<Path>>(path: P)
 			-> Result<Database, Error> {
 		let mut file = match fs::File::open(&path) {
 			Ok(file) => file,
@@ -83,17 +40,7 @@ impl Database {
 
 		let mut buffer = String::new();
 		file.read_to_string(&mut buffer)?;
-		Database::from_str_user_defined(&buffer, home_contract_address, foreign_contract_address)
-	}
-
-	/// Returns a new `Database` constructed from a stored toml string
-	/// containing keys for 'home_contract_address' and
-	/// 'foreign_contract_address'.
-	#[cfg(test)]
-	fn from_str_stored<S: AsRef<str>>(s: S) -> Result<Database, Error> {
-		toml::from_str::<parsed::StoredDatabase>(s.as_ref())
-			.map(Database::from)
-			.map_err(Error::from)
+		Database::from_str(&buffer)
 	}
 
 	/// Returns a new `Database` constructed from the parsed string `s` and
@@ -101,14 +48,11 @@ impl Database {
 	///
 	/// An error will be returned if the `s` contains keys for
 	/// 'home_contract_address' or 'foreign_contract_address'.
-	fn from_str_user_defined<S: AsRef<str>>(s: S, home_contract_address: Address,
-			foreign_contract_address: Address) -> Result<Database, Error> {
-		let db_parsed: parsed::UserDefinedDatabase = toml::from_str(s.as_ref())
+	fn from_str<S: AsRef<str>>(s: S) -> Result<Database, Error> {
+		let db_parsed: parsed::Database = toml::from_str(s.as_ref())
 			.chain_err(|| "Cannot parse database file")?;
 
 		Ok(Database {
-			home_contract_address,
-			foreign_contract_address,
 			home_deploy: db_parsed.home_deploy,
 			foreign_deploy: db_parsed.foreign_deploy,
 			checked_deposit_relay: db_parsed.checked_deposit_relay,
@@ -118,13 +62,7 @@ impl Database {
 	}
 
 	/// Writes a serialized `Database` to a writer.
-	#[deprecated(note = "Use '::store' instead.")]
-	pub fn save<W: Write>(&self, writer: W) -> Result<(), Error> {
-		self.store(writer)
-	}
-
-	/// Writes a serialized `Database` to a writer.
-	pub fn store<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+	pub fn save<W: Write>(&self, mut writer: W) -> Result<(), Error> {
 		writer.write_all(self.to_string().as_bytes())?;
 		Ok(())
 	}
@@ -136,16 +74,10 @@ mod parsed {
 	#[cfg(test)]
 	use toml;
 
-	use super::Address;
-
 	/// Parsed application "database".
 	#[derive(Debug, Deserialize, Serialize)]
 	#[serde(deny_unknown_fields)]
-	pub struct StoredDatabase {
-		/// Address of home contract.
-		pub home_contract_address: Address,
-		/// Address of foreign contract.
-		pub foreign_contract_address: Address,
+	pub struct Database {
 		/// Number of block at which home contract has been deployed.
 		pub home_deploy: Option<u64>,
 		/// Number of block at which foreign contract has been deployed.
@@ -159,30 +91,7 @@ mod parsed {
 	}
 
 	#[cfg(test)]
-	impl fmt::Display for StoredDatabase {
-		fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-			f.write_str(&toml::to_string(self).expect("serialization can't fail; qed"))
-		}
-	}
-
-	/// Parsed application "database".
-	#[derive(Debug, Deserialize, Serialize)]
-	#[serde(deny_unknown_fields)]
-	pub struct UserDefinedDatabase {
-		/// Number of block at which home contract has been deployed.
-		pub home_deploy: Option<u64>,
-		/// Number of block at which foreign contract has been deployed.
-		pub foreign_deploy: Option<u64>,
-		/// Number of last block which has been checked for deposit relays.
-		pub checked_deposit_relay: u64,
-		/// Number of last block which has been checked for withdraw relays.
-		pub checked_withdraw_relay: u64,
-		/// Number of last block which has been checked for withdraw confirms.
-		pub checked_withdraw_confirm: u64,
-	}
-
-	#[cfg(test)]
-	impl fmt::Display for UserDefinedDatabase {
+	impl fmt::Display for Database {
 		fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 			f.write_str(&toml::to_string(self).expect("serialization can't fail; qed"))
 		}
@@ -195,35 +104,7 @@ mod tests {
 	use super::Database;
 
 	#[test]
-	fn database_to_and_from_str_stored() {
-		let toml =
-r#"home_contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db7"
-foreign_contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db8"
-home_deploy = 100
-foreign_deploy = 101
-checked_deposit_relay = 120
-checked_withdraw_relay = 121
-checked_withdraw_confirm = 121
-"#;
-
-		let expected = Database {
-			home_contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db7".into(),
-			foreign_contract_address: "49edf201c1e139282643d5e7c6fb0c7219ad1db8".into(),
-			home_deploy: Some(100),
-			foreign_deploy: Some(101),
-			checked_deposit_relay: 120,
-			checked_withdraw_relay: 121,
-			checked_withdraw_confirm: 121,
-		};
-
-		let database = Database::from_str_stored(toml).unwrap();
-		assert_eq!(expected, database);
-		let s = database.to_string();
-		assert_eq!(s, toml);
-	}
-
-	#[test]
-	fn database_to_and_from_str_user_defined() {
+	fn database_to_and_from_str() {
 		let toml =
 r#"home_deploy = 100
 foreign_deploy = 101
@@ -232,12 +113,7 @@ checked_withdraw_relay = 121
 checked_withdraw_confirm = 121
 "#;
 
-		let home_contract_address = "49edf201c1e139282643d5e7c6fb0c7219ad1db7".into();
-		let foreign_contract_address = "49edf201c1e139282643d5e7c6fb0c7219ad1db8".into();
-
 		let expected = Database {
-			home_contract_address,
-			foreign_contract_address,
 			home_deploy: Some(100),
 			foreign_deploy: Some(101),
 			checked_deposit_relay: 120,
@@ -245,8 +121,7 @@ checked_withdraw_confirm = 121
 			checked_withdraw_confirm: 121,
 		};
 
-		let database = Database::from_str_user_defined(toml,
-			home_contract_address, foreign_contract_address).unwrap();
+		let database = Database::from_str(toml).unwrap();
 		assert_eq!(expected, database);
 		let s = database.to_string();
 		assert!(s.contains(toml));

--- a/bridge/src/database.rs
+++ b/bridge/src/database.rs
@@ -49,7 +49,7 @@ impl Database {
 	/// An error will be returned if the `s` contains keys for
 	/// 'home_contract_address' or 'foreign_contract_address'.
 	fn from_str<S: AsRef<str>>(s: S) -> Result<Database, Error> {
-		let db_parsed: parsed::Database = toml::from_str(s.as_ref())
+		let db_parsed: parse::Database = toml::from_str(s.as_ref())
 			.chain_err(|| "Cannot parse database file")?;
 
 		Ok(Database {
@@ -68,7 +68,7 @@ impl Database {
 	}
 }
 
-mod parsed {
+mod parse {
 	#[cfg(test)]
 	use std::fmt;
 	#[cfg(test)]

--- a/bridge/src/database.rs
+++ b/bridge/src/database.rs
@@ -5,6 +5,7 @@ use web3::types::Address;
 use toml;
 use error::{Error, ResultExt, ErrorKind};
 
+
 /// Application "database".
 #[derive(Debug, PartialEq, Deserialize, Serialize, Default, Clone)]
 pub struct Database {
@@ -24,11 +25,17 @@ pub struct Database {
 	pub checked_withdraw_confirm: u64,
 }
 
-impl str::FromStr for Database {
-	type Err = Error;
-
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		toml::from_str(s).chain_err(|| "Cannot parse database")
+impl From<parsed::StoredDatabase> for Database {
+	fn from(db_parsed: parsed::StoredDatabase) -> Database {
+		Database {
+			home_contract_address: db_parsed.home_contract_address,
+			foreign_contract_address: db_parsed.foreign_contract_address,
+			home_deploy: db_parsed.home_deploy,
+			foreign_deploy: db_parsed.foreign_deploy,
+			checked_deposit_relay: db_parsed.checked_deposit_relay,
+			checked_withdraw_relay: db_parsed.checked_withdraw_relay,
+			checked_withdraw_confirm: db_parsed.checked_withdraw_confirm,
+		}
 	}
 }
 
@@ -39,30 +46,156 @@ impl fmt::Display for Database {
 }
 
 impl Database {
+	/// Loads the toml file specified by `path` and returns a new `Database`
+	/// containing its parsed contents.
+	#[deprecated(note = "Use '::load_stored' instead.")]
 	pub fn load<P: AsRef<Path>>(path: P) -> Result<Database, Error> {
+		Self::load_stored(path)
+	}
+
+	/// Loads the toml file specified by `path` and returns a new `Database`
+	/// containing its parsed contents.
+	pub fn load_stored<P: AsRef<Path>>(path: P) -> Result<Database, Error> {
 		let mut file = match fs::File::open(&path) {
 			Ok(file) => file,
-			Err(ref err) if err.kind() == io::ErrorKind::NotFound => return Err(ErrorKind::MissingFile(format!("{:?}", path.as_ref())).into()),
-			Err(err) => return Err(err).chain_err(|| "Cannot open database"),
+			Err(ref err) if err.kind() == io::ErrorKind::NotFound =>
+				return Err(ErrorKind::MissingFile(format!("{:?}", path.as_ref())).into()),
+			Err(err) => return Err(err).chain_err(|| "Cannot open database file"),
 		};
 
 		let mut buffer = String::new();
 		file.read_to_string(&mut buffer)?;
-		buffer.parse()
+		Ok(toml::from_str::<parsed::StoredDatabase>(&buffer)?.into())
+
 	}
 
-	pub fn save<W: Write>(&self, mut write: W) -> Result<(), Error> {
-		write.write_all(self.to_string().as_bytes())?;
+	/// Loads a user defined toml file specified by `path` and returns a new
+	/// `Database` containing its parsed contents.
+	pub fn load_user_defined<P: AsRef<Path>>(path: P, home_contract_address: Address,
+			foreign_contract_address: Address)
+			-> Result<Database, Error> {
+		let mut file = match fs::File::open(&path) {
+			Ok(file) => file,
+			Err(ref err) if err.kind() == io::ErrorKind::NotFound =>
+				return Err(ErrorKind::MissingFile(format!("{:?}", path.as_ref())).into()),
+			Err(err) => return Err(err).chain_err(|| "Cannot open database file"),
+		};
+
+		let mut buffer = String::new();
+		file.read_to_string(&mut buffer)?;
+		Database::from_str_user_defined(&buffer, home_contract_address, foreign_contract_address)
+	}
+
+	/// Returns a new `Database` constructed from a stored toml string
+	/// containing keys for 'home_contract_address' and
+	/// 'foreign_contract_address'.
+	#[cfg(test)]
+	fn from_str_stored<S: AsRef<str>>(s: S) -> Result<Database, Error> {
+		toml::from_str::<parsed::StoredDatabase>(s.as_ref())
+			.map(Database::from)
+			.map_err(Error::from)
+	}
+
+	/// Returns a new `Database` constructed from the parsed string `s` and
+	/// the provided addresses.
+	///
+	/// An error will be returned if the `s` contains keys for
+	/// 'home_contract_address' or 'foreign_contract_address'.
+	fn from_str_user_defined<S: AsRef<str>>(s: S, home_contract_address: Address,
+			foreign_contract_address: Address) -> Result<Database, Error> {
+		let db_parsed: parsed::UserDefinedDatabase = toml::from_str(s.as_ref())
+			.chain_err(|| "Cannot parse database file")?;
+
+		Ok(Database {
+			home_contract_address,
+			foreign_contract_address,
+			home_deploy: db_parsed.home_deploy,
+			foreign_deploy: db_parsed.foreign_deploy,
+			checked_deposit_relay: db_parsed.checked_deposit_relay,
+			checked_withdraw_relay: db_parsed.checked_withdraw_relay,
+			checked_withdraw_confirm: db_parsed.checked_withdraw_confirm,
+		})
+	}
+
+	/// Writes a serialized `Database` to a writer.
+	#[deprecated(note = "Use '::store' instead.")]
+	pub fn save<W: Write>(&self, writer: W) -> Result<(), Error> {
+		self.store(writer)
+	}
+
+	/// Writes a serialized `Database` to a writer.
+	pub fn store<W: Write>(&self, mut writer: W) -> Result<(), Error> {
+		writer.write_all(self.to_string().as_bytes())?;
 		Ok(())
 	}
 }
+
+mod parsed {
+	#[cfg(test)]
+	use std::fmt;
+	#[cfg(test)]
+	use toml;
+
+	use super::Address;
+
+	/// Parsed application "database".
+	#[derive(Debug, Deserialize, Serialize)]
+	#[serde(deny_unknown_fields)]
+	pub struct StoredDatabase {
+		/// Address of home contract.
+		pub home_contract_address: Address,
+		/// Address of foreign contract.
+		pub foreign_contract_address: Address,
+		/// Number of block at which home contract has been deployed.
+		pub home_deploy: Option<u64>,
+		/// Number of block at which foreign contract has been deployed.
+		pub foreign_deploy: Option<u64>,
+		/// Number of last block which has been checked for deposit relays.
+		pub checked_deposit_relay: u64,
+		/// Number of last block which has been checked for withdraw relays.
+		pub checked_withdraw_relay: u64,
+		/// Number of last block which has been checked for withdraw confirms.
+		pub checked_withdraw_confirm: u64,
+	}
+
+	#[cfg(test)]
+	impl fmt::Display for StoredDatabase {
+		fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+			f.write_str(&toml::to_string(self).expect("serialization can't fail; qed"))
+		}
+	}
+
+	/// Parsed application "database".
+	#[derive(Debug, Deserialize, Serialize)]
+	#[serde(deny_unknown_fields)]
+	pub struct UserDefinedDatabase {
+		/// Number of block at which home contract has been deployed.
+		pub home_deploy: Option<u64>,
+		/// Number of block at which foreign contract has been deployed.
+		pub foreign_deploy: Option<u64>,
+		/// Number of last block which has been checked for deposit relays.
+		pub checked_deposit_relay: u64,
+		/// Number of last block which has been checked for withdraw relays.
+		pub checked_withdraw_relay: u64,
+		/// Number of last block which has been checked for withdraw confirms.
+		pub checked_withdraw_confirm: u64,
+	}
+
+	#[cfg(test)]
+	impl fmt::Display for UserDefinedDatabase {
+		fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+			f.write_str(&toml::to_string(self).expect("serialization can't fail; qed"))
+		}
+	}
+}
+
 
 #[cfg(test)]
 mod tests {
 	use super::Database;
 
 	#[test]
-	fn database_to_and_from_str() {
+	fn database_to_and_from_str_stored() {
 		let toml =
 r#"home_contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db7"
 foreign_contract_address = "0x49edf201c1e139282643d5e7c6fb0c7219ad1db8"
@@ -83,9 +216,39 @@ checked_withdraw_confirm = 121
 			checked_withdraw_confirm: 121,
 		};
 
-		let database = toml.parse().unwrap();
+		let database = Database::from_str_stored(toml).unwrap();
 		assert_eq!(expected, database);
 		let s = database.to_string();
 		assert_eq!(s, toml);
+	}
+
+	#[test]
+	fn database_to_and_from_str_user_defined() {
+		let toml =
+r#"home_deploy = 100
+foreign_deploy = 101
+checked_deposit_relay = 120
+checked_withdraw_relay = 121
+checked_withdraw_confirm = 121
+"#;
+
+		let home_contract_address = "49edf201c1e139282643d5e7c6fb0c7219ad1db7".into();
+		let foreign_contract_address = "49edf201c1e139282643d5e7c6fb0c7219ad1db8".into();
+
+		let expected = Database {
+			home_contract_address,
+			foreign_contract_address,
+			home_deploy: Some(100),
+			foreign_deploy: Some(101),
+			checked_deposit_relay: 120,
+			checked_withdraw_relay: 121,
+			checked_withdraw_confirm: 121,
+		};
+
+		let database = Database::from_str_user_defined(toml,
+			home_contract_address, foreign_contract_address).unwrap();
+		assert_eq!(expected, database);
+		let s = database.to_string();
+		assert!(s.contains(toml));
 	}
 }

--- a/bridge/src/database.rs
+++ b/bridge/src/database.rs
@@ -49,7 +49,7 @@ impl Database {
 	/// An error will be returned if the `s` contains keys for
 	/// 'home_contract_address' or 'foreign_contract_address'.
 	fn from_str<S: AsRef<str>>(s: S) -> Result<Database, Error> {
-		let db_parsed: parse::Database = toml::from_str(s.as_ref())
+		let db_parsed: Database = toml::from_str(s.as_ref())
 			.chain_err(|| "Cannot parse database file")?;
 
 		Ok(Database {
@@ -65,36 +65,6 @@ impl Database {
 	pub fn save<W: Write>(&self, mut writer: W) -> Result<(), Error> {
 		writer.write_all(self.to_string().as_bytes())?;
 		Ok(())
-	}
-}
-
-mod parse {
-	#[cfg(test)]
-	use std::fmt;
-	#[cfg(test)]
-	use toml;
-
-	/// Parsed application "database".
-	#[derive(Debug, Deserialize, Serialize)]
-	#[serde(deny_unknown_fields)]
-	pub struct Database {
-		/// Number of block at which home contract has been deployed.
-		pub home_deploy: Option<u64>,
-		/// Number of block at which foreign contract has been deployed.
-		pub foreign_deploy: Option<u64>,
-		/// Number of last block which has been checked for deposit relays.
-		pub checked_deposit_relay: u64,
-		/// Number of last block which has been checked for withdraw relays.
-		pub checked_withdraw_relay: u64,
-		/// Number of last block which has been checked for withdraw confirms.
-		pub checked_withdraw_confirm: u64,
-	}
-
-	#[cfg(test)]
-	impl fmt::Display for Database {
-		fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-			f.write_str(&toml::to_string(self).expect("serialization can't fail; qed"))
-		}
 	}
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -176,7 +176,7 @@ fn execute<S, I>(command: I, running: Arc<AtomicBool>) -> Result<String, UserFac
 		Deployed::New(database) => {
 			info!(target: "bridge", "Deployed new bridge contracts");
 			info!(target: "bridge", "\n\n{}\n", database);
-			database.store(fs::File::create(&app.database_path)?)?;
+			database.save(fs::File::create(&app.database_path)?)?;
 			database
 		},
 		Deployed::Existing(database) => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -143,14 +143,12 @@ fn execute<S, I>(command: I, running: Arc<AtomicBool>) -> Result<String, UserFac
 
 	info!(target:"bridge", "  using RPC connection");
 	let app = match App::new_http(config.clone(), &args.arg_database, &handle, running.clone()) {
-		Ok(app) => app,
+		Ok(app) => Arc::new(app),
 		Err(e) => {
 			warn!("Can't establish an RPC connection: {:?}", e);
 			return Err((ERR_CANNOT_CONNECT, e).into());
 		},
 	};
-
-	let app = Arc::new(app);
 
 	info!(target: "bridge", "Acquiring home & foreign chain ids");
 	let home_chain_id = event_loop.run(create_chain_id_retrieval(app.clone(), app.connections.home.clone(), app.config.home.clone())).expect("can't retrieve home chain_id");
@@ -178,7 +176,7 @@ fn execute<S, I>(command: I, running: Arc<AtomicBool>) -> Result<String, UserFac
 		Deployed::New(database) => {
 			info!(target: "bridge", "Deployed new bridge contracts");
 			info!(target: "bridge", "\n\n{}\n", database);
-			database.save(fs::File::create(&app.database_path)?)?;
+			database.store(fs::File::create(&app.database_path)?)?;
 			database
 		},
 		Deployed::Existing(database) => {


### PR DESCRIPTION
## Changes

* Remove contract addresses from `Database` and add to `Node`.
* Rename the `config::load` module to `parse`.
* Update tests and README.

### Side Comments and Suggestions

* The `Error` type needs to be redesigned using the `failure` crate rather  than `error_chain`. `error_chain` encourages the use of string errors, which are largely useless to library consumers. Precise types are needed for every error. String-only errors should be forbidden.
* Formatting needs improvement (tabs -> spaces, line width).
* Fields within `Database`, `Config`, and many other structs are declared `pub`. Leaving struct fields public is rarely a good idea, it's convenient at first but it can create situations where fields could possibly be accidentally mutated when they shouldn't be. This might not seem to be possible for many of the structs because they're generally contained in an `App` and therefore an `Arc`, making them immutable in that case, but the idiomatic solution is to create getter methods (and setter when necessary). Who knows what future library changes could accidentally expose a field to mutation in an unintended way. If fields do not need to be exposed publicly `pub(crate)` is an ok solution but can still leaves the door open for potential future bugs to creep in.
* The tests within `integration-tests` fail. This has nothing to do with the changes made here. I don't see an issue for this.

If reviewers feel the above suggestions warrant more attention, let me know and I will create issues for each (and happily tackle those issues).

Closes #101 